### PR TITLE
[WIP] Enable Corosync authentication

### DIFF
--- a/manifests/spof.pp
+++ b/manifests/spof.pp
@@ -77,7 +77,7 @@ class cloud::spof(
   } else {
 
     class { 'corosync':
-      enable_secauth    => false,
+      enable_secauth    => true,
       authkey           => '/var/lib/puppet/ssl/certs/ca.pem',
       bind_address      => $cluster_ip,
       multicast_address => $multicast_address

--- a/spec/classes/cloud_spof_spec.rb
+++ b/spec/classes/cloud_spof_spec.rb
@@ -36,7 +36,7 @@ describe 'cloud::spof' do
 
       it 'configure pacemaker/corosync' do
         is_expected.to contain_class('corosync').with(
-          :enable_secauth    => false,
+          :enable_secauth    => true,
           :authkey           => '/var/lib/puppet/ssl/certs/ca.pem',
           :bind_address      => '10.0.0.1',
           :multicast_address => '239.1.1.2',


### PR DESCRIPTION
We had a situation where other nodes from anywhere else joined our
cluster on the cloud controller. This should never happen again.
Using the Puppet infrastructure's ca as the authkey, this means any
node in Puppet can join the cluster.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
